### PR TITLE
fix: Avoids incompatible data types when attribute is null but casted to empty instead

### DIFF
--- a/src/Models/Sepomex.php
+++ b/src/Models/Sepomex.php
@@ -97,7 +97,7 @@ class Sepomex extends Model
     protected function hasAttributes(array $attributes)
     {
         foreach ($attributes as $attr) {
-            if (! Arr::has($this->attributes, $attr)) {
+            if (! $this->attributes[$attr]) {
                 return false;
             }
         }


### PR DESCRIPTION
Got this error because the attributes were in fact null, but also casted to integer so instead of checking for a column, we validate that the attribute isn't empty...

<img width="520" alt="Screen Shot 2022-03-23 at 21 32 35" src="https://user-images.githubusercontent.com/8600559/159836735-c2aaf1c9-e9ec-4ea9-b71c-20ae0bcdfddb.png">
